### PR TITLE
Pager is not completely centered because of the right margin on the last li element

### DIFF
--- a/src/slippry.scss
+++ b/src/slippry.scss
@@ -289,6 +289,9 @@ $arrows_url: '/images/arrows.svg' !default;
     height: $pager_size;
     margin: 0 1em 0 0;
     @include border-radius(50%);
+    &:last-child{
+	     margin-right: 0;
+    }
     &.sy-active {
       a {
         background-color: $color_high;


### PR DESCRIPTION
I removed the right margin of the last li element so the pager is completely centered.